### PR TITLE
Upgrade pytz to 2020.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil==2.8.1
-pytz==2019.3
+pytz==2020.1
 requests==2.22.0
 slacker==0.13.0


### PR DESCRIPTION
nudge requires pytz2019.3 however another requirement (which one I
know not, but I'm guessing slacker) pulls in pandas-1.5.1 which
needs pytz>=2020.1
